### PR TITLE
More TP Fixes

### DIFF
--- a/Assets/TurtleRobot.cs
+++ b/Assets/TurtleRobot.cs
@@ -610,7 +610,7 @@ public class TurtleRobot : MonoBehaviour
 
     IEnumerator ProcessTwitchCommand(string command)
     {
-        var split = command.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        var split = command.ToLowerInvariant().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
         if ((new string[] { "up", "u", "down", "d" }).Contains(split[0]))
         {

--- a/Assets/TurtleRobot.cs
+++ b/Assets/TurtleRobot.cs
@@ -612,6 +612,11 @@ public class TurtleRobot : MonoBehaviour
     {
         var split = command.ToLowerInvariant().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
+	    if (split[0] == "press")
+	    {
+		    split = split.Skip(1).ToArray();
+	    }
+
         if ((new string[] { "up", "u", "down", "d" }).Contains(split[0]))
         {
             int amount = 1;

--- a/Assets/TurtleRobot.cs
+++ b/Assets/TurtleRobot.cs
@@ -621,9 +621,9 @@ public class TurtleRobot : MonoBehaviour
         {
             int amount = 1;
 
-            if (split.Length == 2 && "123456789".Contains(split[1]) && int.Parse(split[1]) < 17)
+            if (split.Length == 2 && (!int.TryParse(split[1], out amount) || amount < 1 || amount > 22))
             {
-                amount = int.Parse(split[1]);
+				yield break;
             }
 
             yield return null;


### PR DESCRIPTION
* made command input case insensitive.
* allow the command to start with "press ".
* fix up/down command such that it can actually be pressed more than 9 times.
* Set upper bound to 22, which is equal to a 16 command program getting 3 split command bugs.